### PR TITLE
scale the image instead of adjusting the max width/height

### DIFF
--- a/project-resume/src/pages/homepage/homepage.css
+++ b/project-resume/src/pages/homepage/homepage.css
@@ -35,6 +35,5 @@
 }
 
 .container > img:hover { 
-    max-width: 70%;
-    max-height: 70%;
+    transform: scale(1.1);
 }


### PR DESCRIPTION
CSS defect fix for increasing the size of an icon without it pushing down another icon

https://dev.azure.com/nikkimay96/Interactive%20Resume/_workitems/edit/10